### PR TITLE
Add support for CRD schema URLs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -155,6 +155,7 @@ Flags:
       --openshift                   Use OpenShift schemas instead of upstream Kubernetes
   -o, --output string               The format of the output of this script. Options are: [stdout json]
       --schema-location string      Base URL used to download schemas. Can also be specified with the environment variable KUBEVAL_SCHEMA_LOCATION
+      --crd-schema-location string  Base URL used to download CRD schemas.
       --skip-kinds strings          Comma-separated list of case-sensitive kinds to skip when validating against schemas
       --strict                      Disallow additional properties not in schema
       --version                     version for kubeval

--- a/kubeval/config.go
+++ b/kubeval/config.go
@@ -27,6 +27,11 @@ type Config struct {
 	// found at SchemaLocation
 	AdditionalSchemaLocations []string
 
+	// CRDSchemaLocations is a list of URLs from which to search for Custom
+	// Resource Definition schemas, gien that the desired schema was not found at
+	// SchemaLocation and in AdditionalSchemaLocations.
+	CRDSchemaLocations []string
+
 	// OpenShift represents whether to test against
 	// upstream Kubernetes or the OpenShift schemas
 	OpenShift bool
@@ -77,6 +82,7 @@ func AddKubevalFlags(cmd *cobra.Command, config *Config) *cobra.Command {
 	cmd.Flags().StringSliceVar(&config.KindsToSkip, "skip-kinds", []string{}, "Comma-separated list of case-sensitive kinds to skip when validating against schemas")
 	cmd.Flags().StringVarP(&config.SchemaLocation, "schema-location", "s", "", "Base URL used to download schemas. Can also be specified with the environment variable KUBEVAL_SCHEMA_LOCATION.")
 	cmd.Flags().StringSliceVar(&config.AdditionalSchemaLocations, "additional-schema-locations", []string{}, "Comma-seperated list of secondary base URLs used to download schemas")
+	cmd.Flags().StringSliceVar(&config.CRDSchemaLocations, "crd-schema-locations", []string{}, "Comma-seperated list of CRD URLs used to download schemas")
 	cmd.Flags().StringVarP(&config.KubernetesVersion, "kubernetes-version", "v", "master", "Version of Kubernetes to validate against")
 	cmd.Flags().StringVarP(&config.OutputFormat, "output", "o", "", fmt.Sprintf("The format of the output of this script. Options are: %v", validOutputs()))
 	cmd.Flags().BoolVar(&config.Quiet, "quiet", false, "Silences any output aside from the direct results")

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -177,6 +177,10 @@ func downloadSchema(resource *ValidationResult, schemaCache map[string]*gojsonsc
 		schemaRefs = append(schemaRefs, additionalSchemaRef)
 	}
 
+	for _, crdURL := range config.CRDSchemaLocations {
+		schemaRefs = append(schemaRefs, crdURL)
+	}
+
 	var errors *multierror.Error
 
 	for _, schemaRef := range schemaRefs {


### PR DESCRIPTION
This change adds flag crd-schema-locations which contains URLs for Custom Resource Definition schemas.

```
$ kubeval --crd-schema-locations file:///path/to/crd_schema.json -d /manifests --strict
PASS - /manifests/resource.yaml contains a valid MyCRD
```

I've created an upstream PR as well and hopefully that can get merged: https://github.com/instrumenta/kubeval/pull/219

But there has been little activity on the project for a while, so I'm not sure how maintained it is.